### PR TITLE
corrected target environment arg for ng build

### DIFF
--- a/doc/Step-by-step-publish-to-azure-angular.md
+++ b/doc/Step-by-step-publish-to-azure-angular.md
@@ -83,14 +83,14 @@ Select "**azure-publish-demo-server**" and click "**OK**", then click "**Publish
 The details will be explained in the next lines. Here are the quick steps to publish the **AngularUI** to the Azure
 
 - Run the `yarn` command to restore packages
-- Run the `ng build -prod`
+- Run the `ng build --prod`
 - Copy the web.config file that is placed in **angular** folder root to dist folder
 - Configure the **angular/dist/assets/appconfig.json**
 - Send the required files to the Azure
 
 ### Prepare The Publish Folder
 
-Run the `yarn` command to restore packages and run the `ng build -prod` to create publish folder that named **dist**.
+Run the `yarn` command to restore packages and run the `ng build --prod` to create publish folder that named **dist**.
 
 <img src="images/azure-publish-angular-publish-angular.png">
 


### PR DESCRIPTION
The 'prod' argument requires double dashes on ng6.
Failure to provide this results in error

`Unknown option: '-d'`