### PR TITLE
Fix getting start angular broken link

### DIFF
--- a/docs/en/Getting-Started-Angular-Merged.md
+++ b/docs/en/Getting-Started-Angular-Merged.md
@@ -77,7 +77,7 @@ If you log in to host application, then you will see a page like below:
 
 <img src="images/host-home-page.png" alt="Swagger UI" class="img-thumbnail" />
 
-You can navigate to **Swagger UI**, **Hangfire Dashboard** or **GraphQL Playground** from this page. Note that, by default only Swagger UI is enabled, you can enable Hangfire by following [Hangfire documentation](Hangfire) and GraphQL by following [GraphQL documentation](GraphQL).
+You can navigate to **Swagger UI**, **Hangfire Dashboard** or **GraphQL Playground** from this page. Note that, by default only Swagger UI is enabled, you can enable Hangfire by following [Hangfire documentation](Hangfire-Angular) and GraphQL by following [GraphQL documentation](GraphQL).
 
 For example when you navigate **Swagger UI**, you will see following page:
 

--- a/docs/en/Getting-Started-Angular.md
+++ b/docs/en/Getting-Started-Angular.md
@@ -84,7 +84,7 @@ If you log in to host application, then you will see a page like below:
 
 <img src="images/host-home-page.png" alt="Swagger UI" class="img-thumbnail" />
 
-You can navigate to **Swagger UI**, **Hangfire Dashboard** or **GraphQL Playground** from this page. Note that, by default only Swagger UI is enabled, you can enable Hangfire by following [Hangfire documentation](Hangfire) and GraphQL by following [GraphQL documentation](GraphQL).
+You can navigate to **Swagger UI**, **Hangfire Dashboard** or **GraphQL Playground** from this page. Note that, by default only Swagger UI is enabled, you can enable Hangfire by following [Hangfire documentation](Hangfire-Angular) and GraphQL by following [GraphQL documentation](GraphQL).
 
 For example when you navigate **Swagger UI**, you will see following page:
 


### PR DESCRIPTION
The correct link for hangfire angular should be [docs/en/Hangfire-Angular.md](https://github.com/aspnetzero/documents/blob/master/docs/en/Hangfire-Angular.md)

NB: Hangfire-Angular documentation seems to be incomplete. cc @ismcagdas 