### PR TITLE
enclosed --source $web in "az storage blob delete-batch" with single quotes

### DIFF
--- a/docs/en/Step-by-step-publish-to-azure-angular-staticsite.md
+++ b/docs/en/Step-by-step-publish-to-azure-angular-staticsite.md
@@ -96,7 +96,7 @@ We will create a **RELEASE** pipeline here to do the following:
 - Azure Subscription: ````(select your subscription)````
 - Script Location: ````Inline Script````
 - Inline Script
-  - ````az storage blob delete-batch --account-name [STORAGE-ACCOUNT-NAME] --source $web````
+  - ````az storage blob delete-batch --account-name [STORAGE-ACCOUNT-NAME] --source '$web'````
 
 ##### OPTIONAL (with custom domain): Azure CLI: Settings
 


### PR DESCRIPTION
I was getting an error when attempting to run the az storage blob delete-batch command, I had to enclose $web with single quotes to get it to work and not complain about --source expecting one argument.