### PR TITLE
Update DevExpress-Reporting-Implementation-Angular.md

### DIFF
--- a/docs/en/DevExpress-Reporting-Implementation-Angular.md
+++ b/docs/en/DevExpress-Reporting-Implementation-Angular.md
@@ -197,6 +197,7 @@ public IServiceProvider ConfigureServices(IServiceCollection services)
 ```json
 dependencies: [
     "devextreme": "^23.1.6",
+    "devextreme-angular": "^23.1.6",
     "@devexpress/analytics-core": "^23.1.6",
     "devexpress-reporting-angular": "^23.1.6"
 ]


### PR DESCRIPTION
according to [DevExpress Reporting](https://docs.devexpress.com/XtraReports/119430/web-reporting/angular-reporting/document-viewer/document-viewer-integration-in-angular) you should also install devextreme-angular package as well. without out this package you get this error :./src/main.ts - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Error: Cannot resolve type entity i109.DxButtonModule to symbol