### PR TITLE
Fixed getting started document broken links

### DIFF
--- a/docs/en/Index-Angular.md
+++ b/docs/en/Index-Angular.md
@@ -9,8 +9,8 @@ ASP.NET Zero is a starting point for new web applications with a **modern UI** a
 
 ASP.NET Zero has multiple architecture options. Each option has its own documentation:
 
--   [ASP.NET Core MVC](/aspnet-core-mvc/latest/Getting-Started-Core)
--   [ASP.NET Core & Angular](/aspnet-core-angular/latest/Getting-Started-Angular)
+-   [ASP.NET Core MVC](https://docs.aspnetzero.com/aspnet-core-mvc/latest/Getting-Started-Core)
+-   [ASP.NET Core & Angular](https://docs.aspnetzero.com/aspnet-core-angular/latest/Getting-Started-Angular)
 
 ## Before Getting Started
 

--- a/docs/en/Index-Common.md
+++ b/docs/en/Index-Common.md
@@ -8,10 +8,10 @@ ASP.NET Zero is a starting point for new web applications with a **modern UI** a
 
 ASP.NET Zero has multiple architecture options. Each option has its own documentation:
 
--   [ASP.NET Core MVC](/aspnet-core-mvc/latest/Getting-Started-Core)
--   [ASP.NET Core & Angular](/aspnet-core-angular/latest/Getting-Started-Angular)
--   [ASP.NET MVC 5x & jQuery](/aspnet-mvc-jquery/latest/Getting-Started-Mvc-Angularjs)
--   [ASP.NET MVC 5x & AngularJS 1x](/aspnet-mvc-angularjs/latest/Getting-Started-Mvc-Angularjs)
+-   [ASP.NET Core MVC](https://docs.aspnetzero.com/aspnet-core-mvc/latest/Getting-Started-Core)
+-   [ASP.NET Core & Angular](https://docs.aspnetzero.com/aspnet-core-angular/latest/Getting-Started-Angular)
+-   [ASP.NET MVC 5x & jQuery](https://docs.aspnetzero.com/aspnet-mvc-jquery/latest/Getting-Started-Mvc-Angularjs)
+-   [ASP.NET MVC 5x & AngularJS 1x](https://docs.aspnetzero.com/aspnet-mvc-angularjs/latest/Getting-Started-Mvc-Angularjs)
 
 ## Before Getting Started
 


### PR DESCRIPTION
Since they are under different project types and the page route has been added to the beginning of the document site link, it has been corrected to be the full path.