### PR TITLE
Fixed broken links in Introducing v14 blog

### DIFF
--- a/blog-posts/en/Introducing-aspnetzero-v14.md
+++ b/blog-posts/en/Introducing-aspnetzero-v14.md
@@ -63,8 +63,8 @@ For more information, see the [ABP 10 release notes](https://github.com/aspnetbo
 
 As we do in every version, we fixed minor padding and margin errors, localization errors, and made improvements for power tools in line with your requests.
 
-* [https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0-rc.1](https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0-rc.1)
-* [https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0](https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0)
+* [https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0-rc.1](https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0.0-rc.1)
+* [https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0](https://github.com/aspnetzero/aspnet-zero-core/releases/tag/v14.0.0)
 
 ## ✏️ Don't Miss Out! 
 


### PR DESCRIPTION
Resolves https://github.com/aspnetzero/aspnet-zero-core/issues/5661

Fixed the release links under Update Packages and Bug Fixes on the Introducing v14 blog to point to the correct page