### PR TITLE
Add IIS MIME type mappings for woff and woff2 fonts

### DIFF
--- a/docs/en/Deployment-Angular-Publish-Azure.md
+++ b/docs/en/Deployment-Angular-Publish-Azure.md
@@ -100,6 +100,17 @@ Run the `yarn` command to restore packages and run the `npm run publish` to publ
 
 Copy the web.config file that is placed in **angular** folder to **angular/dist** folder.
 
+If the Angular app is hosted on Windows/IIS, make sure the `staticContent` section includes MIME type mappings for `.woff` and `.woff2`. Otherwise, icons and custom fonts may not load correctly.
+
+```xml
+<staticContent>
+  <remove fileExtension=".woff" />
+  <remove fileExtension=".woff2" />
+  <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+  <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+</staticContent>
+```
+
 ### Copy the appconfig.json
 
 Configure the **angular/dist/assets/appconfig.production.json** like following:

--- a/docs/en/Deployment-Angular-Publish-IIS.md
+++ b/docs/en/Deployment-Angular-Publish-IIS.md
@@ -40,3 +40,14 @@ We are using angular-cli for development & deployment. Angular CLI has it's own 
 **Note:** One important thing is that; Angular uses client side routing. If you refresh a page (F5) then IIS will handle the request and will not find the requested path and returns a HTTP 404 error. We should configure IIS to redirect all requests to the index.html page (or, to the root path). At the same time, IIS needs to install the URL Rewrite module, please refer to https://www.iis.net/downloads/microsoft/url-rewrite
 
 ASP.NET Zero Angular UI contains a web.config file. You can copy it to the web site's root folder to overcome the problem described above.
+
+If the Angular app is hosted on Windows/IIS, make sure the `staticContent` section includes MIME type mappings for `.woff` and `.woff2`. Otherwise, icons and custom fonts may not load correctly.
+
+```xml
+<staticContent>
+  <remove fileExtension=".woff" />
+  <remove fileExtension=".woff2" />
+  <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+  <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+</staticContent>
+```

--- a/docs/en/Deployment-React-Publish-Azure.md
+++ b/docs/en/Deployment-React-Publish-Azure.md
@@ -141,11 +141,18 @@ Azure will automatically build and deploy your app on each push.
       </rules>
     </rewrite>
     <staticContent>
+      <remove fileExtension=".json" />
+      <remove fileExtension=".woff" />
+      <remove fileExtension=".woff2" />
       <mimeMap fileExtension=".json" mimeType="application/json" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
     </staticContent>
   </system.webServer>
 </configuration>
 ```
+
+If you host the React app on Windows/IIS, make sure the `.woff` and `.woff2` MIME types are present in `staticContent`. Otherwise, font files may fail to load and icons or custom fonts may not render correctly.
 
 2. Upload all files from the `dist/` folder to the `wwwroot` folder on Azure via FTP or Azure Portal.
 

--- a/docs/en/Deployment-React-Publish-IIS.md
+++ b/docs/en/Deployment-React-Publish-IIS.md
@@ -71,11 +71,17 @@ Create a `web.config` file in the website's root folder with the following conte
     </rewrite>
     <staticContent>
       <remove fileExtension=".json" />
+      <remove fileExtension=".woff" />
+      <remove fileExtension=".woff2" />
       <mimeMap fileExtension=".json" mimeType="application/json" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
     </staticContent>
   </system.webServer>
 </configuration>
 ```
+
+If the React app is hosted on Windows/IIS, these font MIME type mappings are required so `.woff` and `.woff2` files can be served correctly. Without them, icons and custom fonts may not appear in the UI.
 
 ### Create IIS Web Site for React
 


### PR DESCRIPTION
Resolves https://github.com/aspnetzero/aspnet-zero-core/issues/5960

Adds missing .woff and .woff2 MIME type mappings to the IIS deployment documentation and fixes the Angular web.config example. This prevents font and icon loading issues when ASP.NET Zero UI applications are hosted on Windows/IIS.